### PR TITLE
feat: add namespaced-infra-backup relation endpoint

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -42,7 +42,7 @@ config:
       default: kube-system, kube-public, metallb-system
       type: string
 
-requires:
+provides:
   cluster-infra-backup:
     interface: velero_backup_config
     limit: 1

--- a/lib/charms/velero_libs/v0/velero_backup_config.py
+++ b/lib/charms/velero_libs/v0/velero_backup_config.py
@@ -4,9 +4,9 @@ This library implements the Requirer and Provider roles for the `velero_backup_c
 interface. It is used by client charms to declare backup specifications, and by the Velero Operator
 charm to consume them and execute backup and restore operations.
 
-The `velero_backup_config` interface allows a charm (the requirer) to provide a declarative
+The `velero_backup_config` interface allows a charm (the provider) to provide a declarative
 description of what Kubernetes resources should be included in a backup. These specifications are
-sent to the Velero Operator charm (the provider), which executes the backup using the Velero CLI
+sent to the Velero Operator charm (the requirer), which executes the backup using the Velero CLI
 and Kubernetes CRDs.
 
 This interface follows a least-privilege model: client charms do not manipulate cluster resources
@@ -23,28 +23,31 @@ To get started using the library, fetch the library with `charmcraft`.
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.velero_operator.v0.velero_backup_config
+charmcraft fetch-lib charms.velero_libs.v0.velero_backup_config
 ```
 
 Then in your charm, do:
 
 ```python
-from charms.velero_operatpr.v0.velero_backup_config import (
-    VeleroBackupRequirer,
+from charms.velero_libs.v0.velero_backup_config import (
+    VeleroBackupProvider,
     VeleroBackupSpec,
 )
 
 class SomeCharm(CharmBase):
   def __init__(self, *args):
     # ...
-    self.user_workload_backup = VeleroBackupRequirer(
+    self.user_workload_backup = VeleroBackupProvider(
         self,
-        app_name="kubeflow",
         relation_name="user-workloads-backup",
         spec=VeleroBackupSpec(
-            include_namespaces=["user-namespace],
+            include_namespaces=["user-namespace"],
             include_resources=["persistentvolumeclaims", "services", "deployments"],
+            ttl=str(self.config["ttl"]),
         )
+        # Optional, if you want to refresh the data on custom events
+        # In this case, the TTL will be refreshed in the databag on config_changed event
+        refresh_event=[self.on.config_changed]
     )
     # ...
 ```
@@ -75,6 +78,7 @@ DURATION_REGEX = r"^(?=.*\d)(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$"
 SPEC_FIELD = "spec"
 APP_FIELD = "app"
 RELATION_FIELD = "relation_name"
+MODEL_FIELD = "model"
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +92,9 @@ class VeleroBackupSpec(BaseModel):
         exclude_namespaces (Optional[List[str]]): Namespaces to exclude from the backup.
         exclude_resources (Optional[List[str]]): Resources to exclude from the backup.
         label_selector (Optional[Dict[str, str]]): Label selector for filtering resources.
-        include_cluster_resources (bool): Whether to include cluster-wide resources in the backup.
+        include_cluster_resources (Optional[bool]):
+            Whether to include cluster-wide resources in the backup.
+            Defaults to None (auto detect based on resources).
         ttl (Optional[str]): TTL for the backup, if applicable. Example: "24h", "10m10s", etc.
     """
 
@@ -98,7 +104,7 @@ class VeleroBackupSpec(BaseModel):
     exclude_resources: Optional[List[str]] = None
     label_selector: Optional[Dict[str, str]] = None
     ttl: Optional[str] = None
-    include_cluster_resources: bool = False
+    include_cluster_resources: Optional[bool] = None
 
     def __post_init__(self):
         """Validate the specification."""
@@ -108,26 +114,29 @@ class VeleroBackupSpec(BaseModel):
             )
 
 
-class VeleroBackupProvider(Object):
-    """Provider class for the Velero backup configuration relation."""
+class VeleroBackupRequier(Object):
+    """Requirer class for the Velero backup configuration relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str):
-        """Initialize the provider and binds to relation events.
+        """Initialize the requirer.
 
         Args:
-            charm (CharmBase): The charm instance that provides backup configuration.
+            charm (CharmBase): The charm instance that requires backup configuration.
             relation_name (str): The name of the relation. (from metadata.yaml)
         """
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
 
-    def get_backup_spec(self, app_name: str, endpoint: str) -> Optional[VeleroBackupSpec]:
-        """Get a VeleroBackupSpec for a given (app, endpoint).
+    def get_backup_spec(
+        self, app_name: str, endpoint: str, model: str
+    ) -> Optional[VeleroBackupSpec]:
+        """Get a VeleroBackupSpec for a given (app, endpoint, model).
 
         Args:
             app_name (str): The name of the application for which the backup is configured
             endpoint (str): The name of the relation. (from metadata.yaml)
+            model (str): The model name of the application.
 
         Returns:
             Optional[VeleroBackupSpec]: The backup specification if available, otherwise None.
@@ -135,14 +144,13 @@ class VeleroBackupProvider(Object):
         relations = self.model.relations[self._relation_name]
 
         for relation in relations:
-            related_app = relation.app
-            if related_app.name != app_name:
-                continue
-
-            related_app_endpoint = relation.data[related_app].get(RELATION_FIELD, None)
-
-            if related_app_endpoint and related_app_endpoint == endpoint:
-                json_data = relation.data[relation.app].get(SPEC_FIELD, "{}")
+            data = relation.data.get(relation.app, {})
+            if (
+                data.get(APP_FIELD) == app_name
+                and data.get(MODEL_FIELD) == model
+                and data.get(RELATION_FIELD) == endpoint
+            ):
+                json_data = data.get(SPEC_FIELD, "{}")
                 return VeleroBackupSpec.model_validate_json(json_data)
 
         logger.warning("No backup spec found for app '%s' and endpoint '%s'", app_name, endpoint)
@@ -164,22 +172,20 @@ class VeleroBackupProvider(Object):
         return specs
 
 
-class VeleroBackupRequirer(Object):
-    """Requirer class for the Velero backup configuration relation."""
+class VeleroBackupProvider(Object):
+    """Provider class for the Velero backup configuration relation."""
 
     def __init__(
         self,
         charm: CharmBase,
-        app_name: str,
         relation_name: str,
         spec: VeleroBackupSpec,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
     ):
-        """Intialize the requirer with the specified backup configuration.
+        """Intialize the provider with the specified backup configuration.
 
         Args:
-            charm (CharmBase): The charm instance that requires backup.
-            app_name (str): The name of the application for which the backup is configured
+            charm (CharmBase): The charm instance that provides backup.
             relation_name (str): The name of the relation. (from metadata.yaml)
             spec (VeleroBackupSpec): The backup specification to be used
             refresh_event (Optional[Union[BoundEvent, List[BoundEvent]]]):
@@ -187,7 +193,8 @@ class VeleroBackupRequirer(Object):
         """
         super().__init__(charm, relation_name)
         self._charm = charm
-        self._app_name = app_name
+        self._app_name = self._charm.app.name
+        self._model = self._charm.model.name
         self._relation_name = relation_name
         self._spec = spec
 
@@ -207,7 +214,7 @@ class VeleroBackupRequirer(Object):
         """Handle any event where we should send data to the relation."""
         if not self._charm.model.unit.is_leader():
             logger.warning(
-                "VeleroBackupRequirer handled send_data event when it is not a leader. "
+                "VeleroBackupProvider handled send_data event when it is not a leader. "
                 "Skiping event - no data sent"
             )
             return
@@ -216,7 +223,7 @@ class VeleroBackupRequirer(Object):
 
         if not relations:
             logger.warning(
-                "VeleroBackupRequirer handled send_data event but no relation '%s' found "
+                "VeleroBackupProvider handled send_data event but no relation '%s' found "
                 "Skiping event - no data sent",
                 self._relation_name,
             )
@@ -224,6 +231,7 @@ class VeleroBackupRequirer(Object):
         for relation in relations:
             relation.data[self._charm.app].update(
                 {
+                    MODEL_FIELD: self._model,
                     APP_FIELD: self._app_name,
                     RELATION_FIELD: self._relation_name,
                     SPEC_FIELD: self._spec.model_dump_json(),

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,7 @@ import logging
 from typing import Optional
 
 import ops
-from charms.velero_libs.v0.velero_backup_config import VeleroBackupRequirer, VeleroBackupSpec
+from charms.velero_libs.v0.velero_backup_config import VeleroBackupProvider, VeleroBackupSpec
 
 from k8s_utils import K8sUtils, K8sUtilsError
 from literals import (
@@ -29,8 +29,8 @@ class InfraBackupOperatorCharm(ops.CharmBase):
         super().__init__(framework)
         self.k8s_utils = K8sUtils(self.unit.app.name)
         self.setup_failure: Optional[ops.StatusBase] = None
-        self.cluster_infra_backup: Optional[VeleroBackupRequirer] = None
-        self.namespaced_infra_backup: Optional[VeleroBackupRequirer] = None
+        self.cluster_infra_backup: Optional[VeleroBackupProvider] = None
+        self.namespaced_infra_backup: Optional[VeleroBackupProvider] = None
 
         self.framework.observe(self.on.install, self._assess_cluster_backup_state)
         self.framework.observe(self.on.config_changed, self._assess_cluster_backup_state)
@@ -91,9 +91,8 @@ class InfraBackupOperatorCharm(ops.CharmBase):
             return
 
         backup_namespaces = sorted(cluster_namespaces & config.backup_namespaces)
-        self.cluster_infra_backup = VeleroBackupRequirer(
+        self.cluster_infra_backup = VeleroBackupProvider(
             self,
-            app_name=self.unit.app.name,
             relation_name=CLUSTER_INFRA_BACKUP,
             spec=VeleroBackupSpec(
                 include_namespaces=backup_namespaces,
@@ -111,9 +110,8 @@ class InfraBackupOperatorCharm(ops.CharmBase):
         namespaces. This is essential for preserving cluster functionality and security
         configurations.
         """
-        self.namespaced_infra_backup = VeleroBackupRequirer(
+        self.namespaced_infra_backup = VeleroBackupProvider(
             self,
-            app_name=self.unit.app.name,
             relation_name=NAMESPACED_INFRA_BACKUP,
             spec=VeleroBackupSpec(include_resources=RESOURCES_BACKUP),
             refresh_event=[self.on.upgrade_charm],

--- a/src/literals.py
+++ b/src/literals.py
@@ -7,6 +7,25 @@ from dataclasses import dataclass
 
 CLUSTER_INFRA_BACKUP = "cluster-infra-backup"
 NAMESPACED_INFRA_BACKUP = "namespaced-infra-backup"
+RESOURCES_BACKUP = [
+    "roles",
+    "rolebindings",
+    "networkpolicies",
+    "resourcequotas",
+    "limitranges",
+    "serviceaccounts",
+    "gateways",
+    "grpcroutes",
+    "httproutes",
+    "tlsroutes",
+    "ingresses",
+    "configmaps",
+    "secrets",
+    "cronjobs",
+    "jobs",
+    "horizontalpodautoscalers",
+    "verticalpodautoscalers",
+]
 
 
 NAMESPACE_REGEX = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -61,20 +61,24 @@ def delete_namespace(name: str) -> None:
         raise
 
 
-def get_velero_spec(juju: Juju) -> dict[str, Any]:
+def get_velero_spec(juju: Juju, endpoint: str) -> dict[str, Any]:
     """Get the velero spec in the relation."""
     velero_unit = list(juju.status().apps[VELERO_CHARM].units.keys())[0]
     data = yaml.safe_load(juju.cli("show-unit", velero_unit))
-    app_data_bag = get_app_data_bag(velero_unit, data)
-    return json.loads(app_data_bag["spec"])
+    app_data_bag = get_app_data_bag(velero_unit, data, endpoint)
+    return json.loads(app_data_bag["application-data"]["spec"])
 
 
-def get_app_data_bag(unit: str, data: dict[str, Any]) -> dict[str, Any]:
+def get_app_data_bag(unit: str, data: dict[str, Any], endpoint: str) -> dict[str, Any]:
     """Get the application data bag of Velero Operator where it will configure the backup."""
     relation_data = [v for v in data[unit]["relation-info"] if v["endpoint"] == VELERO_ENDPOINT]
     if len(relation_data) == 0:
         raise ValueError(f"No data found for relation {VELERO_ENDPOINT}")
-    return relation_data[0]["application-data"]
+    for relation in relation_data:
+        logger.warning(relation)
+        if relation["related-endpoint"] == endpoint:
+            return relation
+    return ValueError(f"No data found for endpoint {endpoint}")
 
 
 def get_expected_infra_backup_data_bag(extra_ns: Optional[list[str]] = None) -> dict:
@@ -89,6 +93,36 @@ def get_expected_infra_backup_data_bag(extra_ns: Optional[list[str]] = None) -> 
         "label_selector": None,
         "ttl": None,
         "include_cluster_resources": True,
+    }
+
+
+def get_expected_namespaced_infra_backup_data_bag() -> dict:
+    return {
+        "include_namespaces": None,
+        "include_resources": [
+            "roles",
+            "rolebindings",
+            "networkpolicies",
+            "resourcequotas",
+            "limitranges",
+            "serviceaccounts",
+            "gateways",
+            "grpcroutes",
+            "httproutes",
+            "tlsroutes",
+            "ingresses",
+            "configmaps",
+            "secrets",
+            "cronjobs",
+            "jobs",
+            "horizontalpodautoscalers",
+            "verticalpodautoscalers",
+        ],
+        "exclude_namespaces": None,
+        "exclude_resources": None,
+        "label_selector": None,
+        "ttl": None,
+        "include_cluster_resources": False,
     }
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -74,7 +74,7 @@ def get_app_data_bag(unit: str, data: dict[str, Any], endpoint: str) -> dict[str
         logger.warning(relation)
         if relation["related-endpoint"] == endpoint:
             return relation
-    return ValueError(f"No data found for endpoint {endpoint}")
+    raise ValueError(f"No data found for endpoint {endpoint}")
 
 
 def get_expected_infra_backup_data_bag(extra_ns: Optional[list[str]] = None) -> dict:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -71,7 +71,6 @@ def get_app_data_bag(unit: str, data: dict[str, Any], endpoint: str) -> dict[str
     if len(relation_data) == 0:
         raise ValueError(f"No data found for relation {VELERO_ENDPOINT}")
     for relation in relation_data:
-        logger.warning(relation)
         if relation["related-endpoint"] == endpoint:
             return relation
     raise ValueError(f"No data found for endpoint {endpoint}")
@@ -118,7 +117,7 @@ def get_expected_namespaced_infra_backup_data_bag() -> dict:
         "exclude_resources": None,
         "label_selector": None,
         "ttl": None,
-        "include_cluster_resources": False,
+        "include_cluster_resources": None,
     }
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -69,7 +69,10 @@ def test_infra_backup_relation_update(juju: jubilant.Juju) -> None:
     """metallb-system ns is not included in the backup if doesn't exist."""
     delete_namespace("metallb-system")
     with fast_forward(juju):
-        wait_for_backup_spec(lambda: get_velero_spec(juju), get_expected_infra_backup_data_bag())
+        wait_for_backup_spec(
+            lambda: get_velero_spec(juju, CLUSTER_INFRA_BACKUP),
+            get_expected_infra_backup_data_bag(),
+        )
 
 
 def test_wrong_config_blocks_charm(juju: jubilant.Juju) -> None:


### PR DESCRIPTION
Introduce the namespaced-infra-backup relation, responsible for backing up all namespaced Kubernetes resources that are essential to cluster functionality.
    
This includes critical components like roles, service accounts, networkpolicies and other namespace-scoped resources that contribute to the infrastructure's integrity.

Updated the velero_libs with the changes necessary from provider to requirer to better align with the charm ecosystem. See: https://github.com/canonical/velero-operator/pull/146